### PR TITLE
Made socket communication compatible with Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -215,9 +215,14 @@ def main_coonection_loop(bind_addr, bind_port):
         and closes the connection after 100 failed ping (max_fails)
     """
     s.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-    s.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 1)
-    s.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 1)
-    s.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 100)
+    if hasattr(socket, 'TCP_KEEPIDLE'):
+        s.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 1)
+    elif hasattr(socket, 'TCP_KEEPALIVE'):
+        s.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 1)
+    if hasattr(socket, 'TCP_KEEPINTVL'):
+        s.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 1)
+    if hasattr(socket, 'TCP_KEEPCNT'):
+        s.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 100)
     s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)
     s.bind((bind_addr, bind_port))
     s.listen(1)


### PR DESCRIPTION
Fixed the problem that `TCP_KEEPIDLE`, `TCP_KEEPINTVL` and `TCP_KEEPCNT` are not attributes of the `socket` object in Windows. Verified that the script now works on Windows. It should now work on OS X too (the original shouldn't) but I don't have access to a Mac to test this.